### PR TITLE
feat(#22): build & push Docker image to ghcr workflow for Github Actions

### DIFF
--- a/.github/workflows/CI-package.yml
+++ b/.github/workflows/CI-package.yml
@@ -1,0 +1,59 @@
+name: CI - Build and Push to GHCR
+
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+  
+permissions:
+  contents: read
+  packages: write
+
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: raullopezpenalva/contact-service
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Set up JDK 21
+        uses: actions/setup-java@v5
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: maven
+
+      - name: Run tests
+        run: mvn -B clean test
+
+      - name: Build and Test with Maven
+        run: mvn clean package
+
+
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+    
+      - name: Log in to GitHub Container Registry
+        run: echo "${{ secrets.REGISTRY_TOKEN}}" | docker login ${{ env.REGISTRY }} -u ${{ secrets.REGISTRY_USER }} --password-stdin
+
+      - name: Build Docker Images
+        run: |
+          docker build \
+            -t $REGISTRY/$IMAGE_NAME:${{ github.ref_name }} \
+            -t $REGISTRY/$IMAGE_NAME:latest
+            .
+
+      - name: Push Docker Images to GHCR
+        run: |
+          docker push $REGISTRY/$IMAGE_NAME:${{ github.ref_name }}
+          docker push $REGISTRY/$IMAGE_NAME:latest


### PR DESCRIPTION
- Adds GitHub Actions workflow to run tests and build Docker image
- Pushes latest and ${{ github.ref_name }} tags on release tags
- Requires Actions secrets: REGISTRY_USER, REGISTRY_TOKEN

Closes #22 